### PR TITLE
Fix ignoring top level import error

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,12 @@
 Changes since version 0.6.0
 ===========================
 
+Bug fixes
+---------
+
+* Tests are no longer ignored if there is an import error in the
+  top-level package (#98).
+
 
 Version 0.6.0
 =============

--- a/haas/plugins/discoverer.py
+++ b/haas/plugins/discoverer.py
@@ -26,8 +26,11 @@ def _is_in_package(module_name):
     package = module_name.split('.', 1)[0]
     try:
         __import__(package)
-    except ImportError:
-        return False
+    except ImportError as exc:
+        exc_str = str(exc)
+        # Nasty! But fixes #98.
+        if exc_str == 'No module named {0}'.format(package):
+            return False
     return True
 
 


### PR DESCRIPTION
@itziakos This PR fixes issue #98 (where on any import error from the top-level package causes non-discovery of tests).

Fixes #98, with reference to #113.

This is targeted at v0.6.1.