### PR TITLE
Require init py top package

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,18 @@ Packaging
 
 * Tests can be run on an installed haas tree (PR #112).
 
+Behaviour changes
+-----------------
+
+* Following the stdlib unittest runner behaviour, ``__init__.py`` is
+  required in packages searched for tests (solving #98).
+
+Bug fixes
+---------
+
+* Tests are no longer ignored if there is an import error in the
+  top-level package (#98).
+
 
 Version 0.6.0
 =============

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,7 @@ Behaviour changes
 -----------------
 
 * Following the stdlib unittest runner behaviour, ``__init__.py`` is
-  required in packages searched for tests (solving #98).
+  required in packages searched for tests (#98, #113).
 
 Bug fixes
 ---------

--- a/haas/plugins/discoverer.py
+++ b/haas/plugins/discoverer.py
@@ -22,18 +22,6 @@ from .i_discoverer_plugin import IDiscovererPlugin
 logger = logging.getLogger(__name__)
 
 
-def _is_in_package(module_name):
-    package = module_name.split('.', 1)[0]
-    try:
-        __import__(package)
-    except ImportError as exc:
-        exc_str = str(exc)
-        # Nasty! But fixes #98.
-        if exc_str == 'No module named {0}'.format(package):
-            return False
-    return True
-
-
 def _is_import_error_test(test):
     return isinstance(test, ModuleImportError)
 
@@ -379,17 +367,18 @@ class Discoverer(IDiscovererPlugin):
         try:
             module = get_module_by_name(module_name)
         except ImportError:
-            if _is_in_package(module_name):
-                test = _create_import_error_test(module_name)
-                return self._loader.create_suite((test,))
-            # Non-package import in Python 2.7; we ignore and continue
-            return self._loader.create_suite()
+            test = _create_import_error_test(module_name)
+            return self._loader.create_suite((test,))
         else:
             return self._loader.load_module(module)
 
     def _discover_tests(self, start_directory, top_level_directory, pattern):
         for curdir, dirnames, filenames in os.walk(start_directory):
             logger.debug('Discovering tests in %r', curdir)
+            dirnames[:] = [
+                dirname for dirname in dirnames
+                if os.path.exists(os.path.join(curdir, dirname, '__init__.py'))
+            ]
             for filename in filenames:
                 filepath = os.path.join(curdir, filename)
                 if not match_path(filename, filepath, pattern):

--- a/haas/plugins/discoverer.py
+++ b/haas/plugins/discoverer.py
@@ -26,8 +26,11 @@ def _is_in_package(module_name):
     package = module_name.split('.', 1)[0]
     try:
         __import__(package)
-    except ImportError:
-        return False
+    except ImportError as exc:
+        exc_str = str(exc)
+        # Nasty! But fixes #98.
+        if exc_str == 'No module named {0}'.format(package):
+            return False
     return True
 
 

--- a/haas/plugins/tests/test_discoverer.py
+++ b/haas/plugins/tests/test_discoverer.py
@@ -599,11 +599,6 @@ class TestDiscovererNonPackageImport(unittest.TestCase):
             suite = Discoverer(Loader()).discover(self.tempdir, self.tempdir)
         self.assertEqual(suite.countTestCases(), 0)
 
-    def test_discover_includes_non_packages(self):
-        with cd(self.tempdir):
-            suite = Discoverer(Loader()).discover(self.tempdir, self.tempdir)
-        self.assertEqual(suite.countTestCases(), 0)
-
 
 class TestDiscovererDotInModuleName(unittest.TestCase):
 

--- a/haas/plugins/tests/test_discoverer.py
+++ b/haas/plugins/tests/test_discoverer.py
@@ -594,19 +594,15 @@ class TestDiscovererNonPackageImport(unittest.TestCase):
         del self.modules
         shutil.rmtree(self.tempdir)
 
-    @unittest.skipIf(sys.version_info >= (3, 3),
-                     'Python 3.3+ does not require __init__.py')
     def test_discover_skips_non_packages(self):
         with cd(self.tempdir):
             suite = Discoverer(Loader()).discover(self.tempdir, self.tempdir)
         self.assertEqual(suite.countTestCases(), 0)
 
-    @unittest.skipIf(sys.version_info < (3, 3),
-                     'Python < 3.3 requires __init__.py')
     def test_discover_includes_non_packages(self):
         with cd(self.tempdir):
             suite = Discoverer(Loader()).discover(self.tempdir, self.tempdir)
-        self.assertEqual(suite.countTestCases(), 2)
+        self.assertEqual(suite.countTestCases(), 0)
 
 
 class TestDiscovererDotInModuleName(unittest.TestCase):


### PR DESCRIPTION
@itziakos This is a possible change that would close #113. PR created here for reference in making decision to remove the feature of discovering tests in packages missing __init__.py under Python >= 3.3.