### PR TITLE
Test isolation runner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,37 @@
 language: python
-sudo: false
-python:
-  - 3.5
-  - 3.4
-  - 3.3
-  - 2.7
-  - 2.6
-  - pypy
+
+matrix:
+  include:
+    - python: 2.6
+      sudo: false
+    - python: 2.7
+      sudo: false
+    - python: 3.3
+      sudo: false
+    - python: 3.4
+      sudo: false
+    - python: 3.5
+      sudo: false
+    - python: pypy
+      sudo: required
+      dist: trusty
+
 install:
-  - if ! [[ $TRAVIS_PYTHON_VERSION > '2.6' ]]; then pip install unittest2 ; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2 ; fi
   - pip install coverage
   - pip install coveralls
   - python setup.py develop
   - pip install -r test_requirements.txt
+
 script:
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then coverage run --branch -m unittest2.__main__ discover -v -t . haas; fi
   - if [[ $TRAVIS_PYTHON_VERSION != '2.6' ]]; then coverage run --branch -m unittest discover -v -t . haas; fi
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then python -m haas.__main__; fi
   - if [[ $TRAVIS_PYTHON_VERSION != '2.6' ]]; then python -m haas; fi
+
 notifications:
   email:
     - travis-ci@simonjagoe.com
+
 after_success:
   coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ matrix:
     - python: pypy
       sudo: required
       dist: trusty
+    - python: pypy3
+      sudo: required
+      dist: trusty
 
 install:
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2 ; fi

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,16 @@
 Changes since version 0.7.0
 ===========================
 
+Enhancements
+------------
+
+* The ParallelTestRunner now has an option to force a new process for
+  each test case, enforcing isolation between tests (#138).
+
+Bugs Fixed
+----------
+
+* Haas now correctly specifies its Python 2.6 dependencies (#137).
 
 Version 0.7.0
 =============

--- a/haas/plugins/parallel_runner.py
+++ b/haas/plugins/parallel_runner.py
@@ -65,10 +65,12 @@ class ParallelTestRunner(BaseTestRunner):
 
     """
 
-    def __init__(self, process_count=None, initializer=None, warnings=None):
+    def __init__(self, process_count=None, initializer=None,
+                 maxtasksperchild=None, warnings=None):
         super(ParallelTestRunner, self).__init__(warnings=warnings)
         self.process_count = process_count
         self.initializer = initializer
+        self.maxtasksperchild = maxtasksperchild
 
     @classmethod
     def from_args(cls, args, arg_prefix):
@@ -82,7 +84,8 @@ class ParallelTestRunner(BaseTestRunner):
             module_name, initializer_name = initializer_spec.rsplit('.', 1)
             init_module = get_module_by_name(module_name)
             initializer = getattr(init_module, initializer_name)
-        return cls(process_count=args.processes, initializer=initializer)
+        return cls(process_count=args.processes, initializer=initializer,
+                   maxtasksperchild=args.process_max_tasks)
 
     @classmethod
     def add_parser_arguments(self, parser, option_prefix, dest_prefix):
@@ -93,10 +96,18 @@ class ParallelTestRunner(BaseTestRunner):
             'The dotted module path to a subprocess initialization function. '
             'This function will be passed to the subprocess and called with '
             'zero arguments.')
+        process_maxtasksperchild_help = (
+            'The number of tasks each process is allowed to run before it is '
+            'replaced by a new process.  Defaults to no limit.'
+        )
         parser.add_argument(
             '--processes', help=process_count_help, type=int, default=None)
         parser.add_argument(
             '--process-init', help=process_init_help, default=None)
+        parser.add_argument(
+            '--process-max-tasks', help=process_maxtasksperchild_help,
+            type=int, default=None,
+        )
 
     def _handle_result(self, result, collected_result):
         for test_result in collected_result:
@@ -107,11 +118,12 @@ class ParallelTestRunner(BaseTestRunner):
 
     def _run_tests(self, result, test):
         pool = Pool(processes=self.process_count,
-                    initializer=self.initializer)
+                    initializer=self.initializer,
+                    maxtasksperchild=self.maxtasksperchild)
 
         try:
-            callback = lambda collected_result: self._handle_result(
-                result, collected_result)
+            def callback(collected_result):
+                self._handle_result(result, collected_result)
             error_tests = []
             for test_case in find_test_cases(test):
                 if isinstance(test_case, ModuleImportError):
@@ -132,5 +144,6 @@ class ParallelTestRunner(BaseTestRunner):
         """Run the tests in subprocesses.
 
         """
-        test = lambda result: self._run_tests(result_collector, test_to_run)
+        def test(result):
+            self._run_tests(result_collector, test_to_run)
         return super(ParallelTestRunner, self).run(result_collector, test)

--- a/haas/tests/test_parallel_runner.py
+++ b/haas/tests/test_parallel_runner.py
@@ -98,7 +98,8 @@ class TestParallelTestRunner(unittest.TestCase):
         # Then
         self.assertEqual(result_handler.results, [expected_result])
         pool_class.assert_called_once_with(
-            processes=processes, initializer=None)
+            processes=processes, initializer=None,
+            maxtasksperchild=None)
         pool.close.assert_called_once_with()
         pool.join.assert_called_once_with()
 
@@ -120,7 +121,8 @@ class TestParallelTestRunner(unittest.TestCase):
 
         # Then
         pool_class.assert_called_once_with(
-            processes=None, initializer=None)
+            processes=None, initializer=None,
+            maxtasksperchild=None)
         pool.close.assert_called_once_with()
         pool.join.assert_called_once_with()
         result_collector.startTestRun.assert_called_once_with()
@@ -153,7 +155,8 @@ class TestParallelTestRunner(unittest.TestCase):
         # Then
         self.assertEqual(result_handler.results, [expected_result])
         pool_class.assert_called_once_with(
-            processes=processes, initializer=initializer)
+            processes=processes, initializer=initializer,
+            maxtasksperchild=None)
         pool.close.assert_called_once_with()
         pool.join.assert_called_once_with()
 
@@ -175,7 +178,8 @@ class TestParallelTestRunner(unittest.TestCase):
         parser = ArgumentParser()
         ParallelTestRunner.add_parser_arguments(
             parser, opt_prefix, dest_prefix)
-        args = parser.parse_args(['--processes', '4'])
+        args = parser.parse_args(['--processes', '4',
+                                  '--process-max-tasks', '1'])
 
         result_handler = ChildResultHandler()
         result_collector = ResultCollecter()
@@ -188,7 +192,7 @@ class TestParallelTestRunner(unittest.TestCase):
         # Then
         self.assertEqual(result_handler.results, [expected_result])
         pool_class.assert_called_once_with(
-            processes=4, initializer=None)
+            processes=4, initializer=None, maxtasksperchild=1)
         pool.close.assert_called_once_with()
         pool.join.assert_called_once_with()
 
@@ -227,7 +231,8 @@ class TestParallelTestRunner(unittest.TestCase):
 
         self.assertEqual(result_handler.results, [expected_result])
         pool_class.assert_called_once_with(
-            processes=None, initializer=subprocess_initializer)
+            processes=None, initializer=subprocess_initializer,
+            maxtasksperchild=None)
         pool.close.assert_called_once_with()
         pool.join.assert_called_once_with()
 

--- a/haas/tests/test_parallel_runner.py
+++ b/haas/tests/test_parallel_runner.py
@@ -12,6 +12,15 @@ from ..testing import unittest
 from . import _test_cases
 
 
+class AsyncResult(object):
+
+    def ready(self):
+        return True
+
+    def wait(self, timeout):
+        pass
+
+
 def apply_async(func, args=None, kwargs=None, callback=None):
     if args is None:
         args = ()
@@ -20,6 +29,7 @@ def apply_async(func, args=None, kwargs=None, callback=None):
     result = func(*args, **kwargs)
     if callback is not None:
         callback(result)
+    return AsyncResult()
 
 
 class TestChildResultHandler(unittest.TestCase):


### PR DESCRIPTION
Add option to the parallel test runner to run each unit test in a new subprocess for isolation.

Closes #138 