### PR TITLE
Fix issue #143

### DIFF
--- a/haas/loader.py
+++ b/haas/loader.py
@@ -6,7 +6,7 @@
 # of the 3-clause BSD license.  See the LICENSE.txt file for details.
 from __future__ import absolute_import, unicode_literals
 
-from .testing import unittest
+import unittest
 from .suite import TestSuite
 
 

--- a/haas/plugins/tests/test_discoverer.py
+++ b/haas/plugins/tests/test_discoverer.py
@@ -259,10 +259,10 @@ class TestDiscoveryByPath(TestDiscoveryMixin, unittest.TestCase):
     def assertSuite(self, suite):
         self.assertIsInstance(suite, TestSuite)
         tests = list(self.get_test_cases(suite))
-        self.assertEqual(len(tests), 1)
-        test, = tests
-        self.assertIsInstance(test, python_unittest.TestCase)
-        self.assertEqual(test._testMethodName, 'test_method')
+        self.assertEqual(len(tests), 2)
+        for test in tests:
+            self.assertIsInstance(test, python_unittest.TestCase)
+            self.assertEqual(test._testMethodName, 'test_method')
 
     def test_from_top_level_directory(self):
         suite = self.discoverer.discover(self.tmpdir)
@@ -344,10 +344,10 @@ class TestDiscoveryByModule(TestDiscoveryMixin, unittest.TestCase):
             top_level_directory=self.tmpdir,
         )
         tests = list(self.get_test_cases(suite))
-        self.assertEqual(len(tests), 1)
-        test, = tests
-        self.assertIsInstance(test, python_unittest.TestCase)
-        self.assertEqual(test._testMethodName, 'test_method')
+        self.assertEqual(len(tests), 2)
+        for test in tests:
+            self.assertIsInstance(test, python_unittest.TestCase)
+            self.assertEqual(test._testMethodName, 'test_method')
 
     def test_discover_package_no_top_level(self):
         suite = self.discoverer.discover('haas.tests')
@@ -359,10 +359,10 @@ class TestDiscoveryByModule(TestDiscoveryMixin, unittest.TestCase):
         suite = self.discoverer.discover(
             module, top_level_directory=self.tmpdir)
         tests = list(self.get_test_cases(suite))
-        self.assertEqual(len(tests), 1)
-        test, = tests
-        self.assertIsInstance(test, python_unittest.TestCase)
-        self.assertEqual(test._testMethodName, 'test_method')
+        self.assertEqual(len(tests), 2)
+        for test in tests:
+            self.assertIsInstance(test, python_unittest.TestCase)
+            self.assertEqual(test._testMethodName, 'test_method')
 
     def test_discover_case(self):
         module = '{0}.test_cases.TestCase'.format('.'.join(self.dirs))
@@ -422,10 +422,10 @@ class TestDiscoverFilteredTests(TestDiscoveryMixin, unittest.TestCase):
             top_level_directory=self.tmpdir,
         )
         tests = list(self.get_test_cases(suite))
-        self.assertEqual(len(tests), 1)
-        test, = tests
-        self.assertIsInstance(test, python_unittest.TestCase)
-        self.assertEqual(test._testMethodName, 'test_method')
+        self.assertEqual(len(tests), 2)
+        for test in tests:
+            self.assertIsInstance(test, python_unittest.TestCase)
+            self.assertEqual(test._testMethodName, 'test_method')
 
     def test_discover_test_method(self):
         suite = self.discoverer.discover(
@@ -433,10 +433,10 @@ class TestDiscoverFilteredTests(TestDiscoveryMixin, unittest.TestCase):
             top_level_directory=self.tmpdir,
         )
         tests = list(self.get_test_cases(suite))
-        self.assertEqual(len(tests), 1)
-        test, = tests
-        self.assertIsInstance(test, python_unittest.TestCase)
-        self.assertEqual(test._testMethodName, 'test_method')
+        self.assertEqual(len(tests), 2)
+        for test in tests:
+            self.assertIsInstance(test, python_unittest.TestCase)
+            self.assertEqual(test._testMethodName, 'test_method')
 
     def test_discover_class(self):
         suite = self.discoverer.discover(

--- a/haas/tests/_test_cases.py
+++ b/haas/tests/_test_cases.py
@@ -6,6 +6,8 @@
 # of the 3-clause BSD license.  See the LICENSE.txt file for details.
 from __future__ import absolute_import, unicode_literals
 
+import unittest as python_unittest
+
 from haas.testing import unittest
 
 
@@ -22,6 +24,11 @@ class NotTestCase(object):
 
 
 class TestCase(NotTestCase, unittest.TestCase):
+
+    pass
+
+
+class PythonTestCase(NotTestCase, python_unittest.TestCase):
 
     pass
 

--- a/haas/tests/test_loader.py
+++ b/haas/tests/test_loader.py
@@ -114,22 +114,27 @@ class TestLoadModule(LoaderTestMixin, unittest.TestCase):
     def assertSuiteClasses(self, suite, klass):
         self.assertIsInstance(suite, klass)
         sub_suites = list(suite)
-        self.assertEqual(len(sub_suites), 1)
-        self.assertIsInstance(sub_suites[0], klass)
+        self.assertEqual(len(sub_suites), 2)
+        for sub_suite in sub_suites:
+            self.assertIsInstance(sub_suite, klass)
 
     def test_find_all_cases_in_module(self):
         cases = self.loader.get_test_cases_from_module(_test_cases)
-        self.assertEqual(cases, [_test_cases.TestCase])
+        self.assertItemsEqual(
+            cases, [_test_cases.TestCase, _test_cases.PythonTestCase])
 
     def test_load_all_cases_in_module(self):
         suite = self.loader.load_module(_test_cases)
         self.assertSuiteClasses(suite, TestSuite)
         sub_suites = list(suite)
-        self.assertEqual(len(sub_suites), 1)
-        cases = list(sub_suites[0])
-        self.assertEqual(len(cases), 1)
-        case = cases[0]
-        self.assertIsInstance(case, _test_cases.TestCase)
+        self.assertEqual(len(sub_suites), 2)
+        cases = []
+        for sub_suite in sub_suites:
+            self.assertEqual(len(list(sub_suite)), 1)
+            for case in sub_suite:
+                self.assertIsInstance(case, python_unittest.TestCase)
+                cases.append(case)
+        self.assertEqual(len(cases), 2)
 
     def test_creates_custom_testsuite_subclass(self):
         loader = Loader(test_suite_class=TestSuiteSubclass)

--- a/haas/tests/test_loader.py
+++ b/haas/tests/test_loader.py
@@ -8,6 +8,8 @@ from __future__ import absolute_import, unicode_literals
 
 import unittest as python_unittest
 
+import six
+
 from haas.testing import unittest
 
 from . import _test_cases
@@ -120,7 +122,8 @@ class TestLoadModule(LoaderTestMixin, unittest.TestCase):
 
     def test_find_all_cases_in_module(self):
         cases = self.loader.get_test_cases_from_module(_test_cases)
-        self.assertItemsEqual(
+        six.assertCountEqual(
+            self,
             cases, [_test_cases.TestCase, _test_cases.PythonTestCase])
 
     def test_load_all_cases_in_module(self):


### PR DESCRIPTION
This PR updates the `loader` module so that it always checks for subclasses of `unittest.TestCase` 