### PR TITLE
Change slow test report to test time summary

### DIFF
--- a/haas/plugins/result_handler.py
+++ b/haas/plugins/result_handler.py
@@ -316,7 +316,7 @@ class TimingResultHandler(IResultHandlerPlugin):
         stream.writeln('\n\nTest timing report')
         stream.writeln(self.separator2)
 
-        template = '{0} {1}'
+        template = '  {0} {1}'
 
         for test_result in tests_by_time[:self.number_to_summarize]:
             description = get_test_description(

--- a/haas/plugins/result_handler.py
+++ b/haas/plugins/result_handler.py
@@ -272,6 +272,7 @@ class TimingResultHandler(IResultHandlerPlugin):
     @classmethod
     def add_parser_arguments(cls, parser, name, option_prefix, dest_prefix):
         parser.add_argument('--summarize-test-time', action='store', type=int,
+                            metavar='SHOW_N_SLOW_TESTS',
                             nargs='?', default=cls.OPTION_DEFAULT,
                             help=('Show test time summary and N slowest tests '
                                   '(default 10)'))

--- a/haas/plugins/result_handler.py
+++ b/haas/plugins/result_handler.py
@@ -6,10 +6,11 @@
 # of the 3-clause BSD license.  See the LICENSE.txt file for details.
 from __future__ import absolute_import, unicode_literals
 
+import statistics
 import sys
 import time
 
-from haas.result import TestCompletionStatus, separator2
+from haas.result import TestCompletionStatus, TestDuration, separator2
 from .i_result_handler_plugin import IResultHandlerPlugin
 
 
@@ -293,9 +294,26 @@ class TimingResultHandler(IResultHandlerPlugin):
             key=lambda item: item.duration,
             reverse=True,
         )
+        tests_count = len(tests_by_time)
 
-        self.stream.writeln('\n\nTest timing report')
-        self.stream.writeln(self.separator2)
+        durations = [t.duration for t in tests_by_time]
+        median = statistics.median(t.duration for t in tests_by_time)
+        mean = statistics.median(durations)
+        if len(durations) > 1:
+            stdev = statistics.stdev(
+                t.duration.total_seconds for t in tests_by_time)
+            stdev = TestDuration(stdev)
+        else:
+            stdev = '-'
+
+        percentile_99_index = int(tests_count * 0.01)
+        percentile_95_index = int(tests_count * 0.05)
+        percentile_90_index = int(tests_count * 0.10)
+        percentile_80_index = int(tests_count * 0.20)
+
+        stream = self.stream
+        stream.writeln('\n\nTest timing report')
+        stream.writeln(self.separator2)
 
         template = '{0} {1}'
 
@@ -303,8 +321,31 @@ class TimingResultHandler(IResultHandlerPlugin):
             description = get_test_description(
                 test_result.test, descriptions=self.descriptions)
             line = template.format(str(test_result.duration), description)
-            self.stream.writeln(line)
-        self.stream.writeln()
+            stream.writeln(line)
+
+        stream.writeln()
+
+        pairs = [
+            ['Mean', str(mean).strip()],
+            ['Std Dev', str(stdev).strip()],
+            ['Median', str(median).strip()],
+            ['80%', str(tests_by_time[percentile_99_index].duration).strip()],
+            ['90%', str(tests_by_time[percentile_95_index].duration).strip()],
+            ['95%', str(tests_by_time[percentile_90_index].duration).strip()],
+            ['99%', str(tests_by_time[percentile_80_index].duration).strip()],
+        ]
+        column_lengths = [max(len(item) for item in pair) for pair in pairs]
+        headers, columns = zip(*pairs)
+        header_template = '{item: <{len}}'
+        column_template = '{item: >{len}}'
+        header = ' | '.join(header_template.format(item=h, len=l)
+                            for h, l in zip(headers, column_lengths))
+        separator = '-+-'.join('-' * l for l in column_lengths)
+        row = ' | '.join(column_template.format(item=i, len=l)
+                         for i, l in zip(columns, column_lengths))
+        stream.writeln(' {0}'.format(header))
+        stream.writeln('-{0}-'.format(separator))
+        stream.writeln(' {0}'.format(row))
 
     def __call__(self, result):
         self._test_results.append(result)

--- a/haas/plugins/result_handler.py
+++ b/haas/plugins/result_handler.py
@@ -248,7 +248,7 @@ class VerboseTestResultHandler(StandardTestResultHandler):
         self.stream.flush()
 
 
-class SlowTestsResultHandler(IResultHandlerPlugin):
+class TimingResultHandler(IResultHandlerPlugin):
     separator1 = '=' * 70
     separator2 = separator2
 
@@ -263,16 +263,17 @@ class SlowTestsResultHandler(IResultHandlerPlugin):
 
     @classmethod
     def from_args(cls, args, name, dest_prefix, test_count):
-        if args.summarize_slow_tests is not cls.OPTION_DEFAULT:
-            number_to_summarize = args.summarize_slow_tests or 10
+        if args.summarize_test_time is not cls.OPTION_DEFAULT:
+            number_to_summarize = args.summarize_test_time or 10
             if number_to_summarize > 0:
                 return cls(number_to_summarize)
 
     @classmethod
     def add_parser_arguments(cls, parser, name, option_prefix, dest_prefix):
-        parser.add_argument('--summarize-slow-tests', action='store', type=int,
+        parser.add_argument('--summarize-test-time', action='store', type=int,
                             nargs='?', default=cls.OPTION_DEFAULT,
-                            help='Show N slowest tests (default 10)')
+                            help=('Show test time summary and N slowest tests '
+                                  '(default 10)'))
 
     def start_test(self, test):
         pass
@@ -293,10 +294,7 @@ class SlowTestsResultHandler(IResultHandlerPlugin):
             reverse=True,
         )
 
-        self.stream.writeln()
-        plural = 's' if self.number_to_summarize > 1 else ''
-        self.stream.writeln(
-            '{0} slowest test{1}'.format(self.number_to_summarize, plural))
+        self.stream.writeln('\n\nTest timing report')
         self.stream.writeln(self.separator2)
 
         template = '{0} {1}'

--- a/haas/plugins/result_handler.py
+++ b/haas/plugins/result_handler.py
@@ -334,18 +334,21 @@ class TimingResultHandler(IResultHandlerPlugin):
             ['95%', str(tests_by_time[percentile_90_index].duration).strip()],
             ['99%', str(tests_by_time[percentile_80_index].duration).strip()],
         ]
-        column_lengths = [max(len(item) for item in pair) for pair in pairs]
-        headers, columns = zip(*pairs)
-        header_template = '{item: <{len}}'
-        column_template = '{item: >{len}}'
-        header = ' | '.join(header_template.format(item=h, len=l)
-                            for h, l in zip(headers, column_lengths))
-        separator = '-+-'.join('-' * l for l in column_lengths)
-        row = ' | '.join(column_template.format(item=i, len=l)
-                         for i, l in zip(columns, column_lengths))
-        stream.writeln(' {0}'.format(header))
-        stream.writeln('-{0}-'.format(separator))
-        stream.writeln(' {0}'.format(row))
+        stat_table = _format_stat_table(pairs)
+        stream.writeln(stat_table)
 
     def __call__(self, result):
         self._test_results.append(result)
+
+
+def _format_stat_table(pairs):
+    column_lengths = [max(len(item) for item in pair) for pair in pairs]
+    headers, columns = zip(*pairs)
+    header_template = '{item: <{len}}'
+    column_template = '{item: >{len}}'
+    header = ' | '.join(header_template.format(item=h, len=l)
+                        for h, l in zip(headers, column_lengths))
+    separator = '-+-'.join('-' * l for l in column_lengths)
+    row = ' | '.join(column_template.format(item=i, len=l)
+                     for i, l in zip(columns, column_lengths))
+    return ' {0}\n-{1}-\n {2}'.format(header, separator, row)

--- a/haas/plugins/result_handler.py
+++ b/haas/plugins/result_handler.py
@@ -297,11 +297,11 @@ class TimingResultHandler(IResultHandlerPlugin):
         tests_count = len(tests_by_time)
 
         durations = [t.duration for t in tests_by_time]
-        median = statistics.median(t.duration for t in tests_by_time)
-        mean = statistics.median(durations)
+        median = statistics.median(durations)
+        mean = statistics.mean(durations)
         if len(durations) > 1:
             stdev = statistics.stdev(
-                t.duration.total_seconds for t in tests_by_time)
+                duration.total_seconds for duration in durations)
             stdev = TestDuration(stdev)
         else:
             stdev = '-'

--- a/haas/plugins/tests/test_result_handlers.py
+++ b/haas/plugins/tests/test_result_handlers.py
@@ -9,18 +9,18 @@ from haas.tests import _test_cases
 from haas.tests.fixtures import ExcInfoFixture
 from ..result_handler import (
     QuietTestResultHandler,
-    SlowTestsResultHandler,
+    TimingResultHandler,
     VerboseTestResultHandler,
     sort_result_handlers,
 )
 
 
-class TestSlowTestsResultHandler(ExcInfoFixture, unittest.TestCase):
+class TestTimingResultHandler(ExcInfoFixture, unittest.TestCase):
 
     @patch('sys.stderr', new_callable=StringIO)
     def test_output_start_test_run(self, stderr):
         # Given
-        handler = SlowTestsResultHandler(number_to_summarize=5)
+        handler = TimingResultHandler(number_to_summarize=5)
 
         # When
         handler.start_test_run()
@@ -37,7 +37,7 @@ class TestSlowTestsResultHandler(ExcInfoFixture, unittest.TestCase):
         end_time = start_time + duration
         expected_duration = TestDuration(start_time, end_time)
         case = _test_cases.TestCase('test_method')
-        handler = SlowTestsResultHandler(number_to_summarize=5)
+        handler = TimingResultHandler(number_to_summarize=5)
         handler.start_test_run()
 
         result = TestResult.from_test_case(
@@ -49,7 +49,7 @@ class TestSlowTestsResultHandler(ExcInfoFixture, unittest.TestCase):
 
         # Then
         output = stderr.getvalue()
-        output_start = '\n5 slowest tests\n' + handler.separator2
+        output_start = '\n\nTest timing report\n' + handler.separator2
         self.assertTrue(output.startswith(output_start))
         self.assertRegexpMatches(
             output.replace('\n', ''), r'--+.*?0:00:10\.123 test_method \(')
@@ -59,7 +59,7 @@ class TestSlowTestsResultHandler(ExcInfoFixture, unittest.TestCase):
     def test_output_start_test(self, stderr, mock_ctime):
         # Given
         case = _test_cases.TestCase('test_method')
-        handler = SlowTestsResultHandler(number_to_summarize=5)
+        handler = TimingResultHandler(number_to_summarize=5)
 
         # When
         handler.start_test(case)
@@ -71,7 +71,7 @@ class TestSlowTestsResultHandler(ExcInfoFixture, unittest.TestCase):
     @patch('sys.stderr', new_callable=StringIO)
     def test_no_output_stop_test(self, stderr):
         # Given
-        handler = SlowTestsResultHandler(number_to_summarize=5)
+        handler = TimingResultHandler(number_to_summarize=5)
         case = _test_cases.TestCase('test_method')
 
         # When
@@ -90,7 +90,7 @@ class TestSlowTestsResultHandler(ExcInfoFixture, unittest.TestCase):
         expected_duration = TestDuration(start_time, end_time)
         case = _test_cases.TestCase('test_method')
 
-        handler = SlowTestsResultHandler(number_to_summarize=5)
+        handler = TimingResultHandler(number_to_summarize=5)
         with self.exc_info(RuntimeError) as exc_info:
             result = TestResult.from_test_case(
                 case, TestCompletionStatus.error, expected_duration,
@@ -112,7 +112,7 @@ class TestSlowTestsResultHandler(ExcInfoFixture, unittest.TestCase):
         expected_duration = TestDuration(start_time, end_time)
         case = _test_cases.TestCase('test_method')
 
-        handler = SlowTestsResultHandler(number_to_summarize=5)
+        handler = TimingResultHandler(number_to_summarize=5)
         with self.failure_exc_info() as exc_info:
             result = TestResult.from_test_case(
                 case, TestCompletionStatus.failure, expected_duration,
@@ -134,7 +134,7 @@ class TestSlowTestsResultHandler(ExcInfoFixture, unittest.TestCase):
         expected_duration = TestDuration(start_time, end_time)
         case = _test_cases.TestCase('test_method')
 
-        handler = SlowTestsResultHandler(number_to_summarize=5)
+        handler = TimingResultHandler(number_to_summarize=5)
         result = TestResult.from_test_case(
             case, TestCompletionStatus.success, expected_duration)
 
@@ -154,7 +154,7 @@ class TestSlowTestsResultHandler(ExcInfoFixture, unittest.TestCase):
         expected_duration = TestDuration(start_time, end_time)
         case = _test_cases.TestCase('test_method')
 
-        handler = SlowTestsResultHandler(number_to_summarize=5)
+        handler = TimingResultHandler(number_to_summarize=5)
         result = TestResult.from_test_case(
             case, TestCompletionStatus.skipped, expected_duration,
             message='reason')
@@ -175,7 +175,7 @@ class TestSlowTestsResultHandler(ExcInfoFixture, unittest.TestCase):
         expected_duration = TestDuration(start_time, end_time)
         case = _test_cases.TestCase('test_method')
 
-        handler = SlowTestsResultHandler(number_to_summarize=5)
+        handler = TimingResultHandler(number_to_summarize=5)
         with self.exc_info(RuntimeError) as exc_info:
             result = TestResult.from_test_case(
                 case, TestCompletionStatus.expected_failure, expected_duration,
@@ -197,7 +197,7 @@ class TestSlowTestsResultHandler(ExcInfoFixture, unittest.TestCase):
         expected_duration = TestDuration(start_time, end_time)
         case = _test_cases.TestCase('test_method')
 
-        handler = SlowTestsResultHandler(number_to_summarize=5)
+        handler = TimingResultHandler(number_to_summarize=5)
         result = TestResult.from_test_case(
             case, TestCompletionStatus.unexpected_success, expected_duration)
 
@@ -217,7 +217,7 @@ class TestSlowTestsResultHandler(ExcInfoFixture, unittest.TestCase):
         expected_duration = TestDuration(start_time, end_time)
         case = _test_cases.TestCase('test_method')
 
-        handler = SlowTestsResultHandler(number_to_summarize=5)
+        handler = TimingResultHandler(number_to_summarize=5)
         handler.start_test_run()
         with self.exc_info(RuntimeError) as exc_info:
             result = TestResult.from_test_case(
@@ -230,7 +230,7 @@ class TestSlowTestsResultHandler(ExcInfoFixture, unittest.TestCase):
 
         # Then
         output = stderr.getvalue()
-        output_start = '\n5 slowest tests\n' + handler.separator2
+        output_start = '\n\nTest timing report\n' + handler.separator2
         self.assertTrue(output.startswith(output_start))
         self.assertRegexpMatches(
             output.replace('\n', ''), r'--+.*?1543:00:12\.234 test_method \(')
@@ -244,7 +244,7 @@ class TestSlowTestsResultHandler(ExcInfoFixture, unittest.TestCase):
         expected_duration = TestDuration(start_time, end_time)
         case = _test_cases.TestCase('test_method')
 
-        handler = SlowTestsResultHandler(number_to_summarize=5)
+        handler = TimingResultHandler(number_to_summarize=5)
         handler.start_test_run()
         with self.failure_exc_info() as exc_info:
             result = TestResult.from_test_case(
@@ -257,7 +257,7 @@ class TestSlowTestsResultHandler(ExcInfoFixture, unittest.TestCase):
 
         # Then
         output = stderr.getvalue()
-        output_start = '\n5 slowest tests\n' + handler.separator2
+        output_start = '\n\nTest timing report\n' + handler.separator2
         self.assertTrue(output.startswith(output_start))
         self.assertRegexpMatches(
             output.replace('\n', ''), r'--+.*?1:01:14\.567 test_method \(')
@@ -267,7 +267,7 @@ class TestSortResultHandlers(unittest.TestCase):
 
     def test_sort_result_handlers(self):
         # Given
-        handlers = [QuietTestResultHandler(5), SlowTestsResultHandler(5)]
+        handlers = [QuietTestResultHandler(5), TimingResultHandler(5)]
         expected = handlers[::-1]
 
         # When
@@ -279,7 +279,7 @@ class TestSortResultHandlers(unittest.TestCase):
     def test_sort_result_handlers_multiple_core(self):
         # Given
         handlers = [VerboseTestResultHandler(5), QuietTestResultHandler(5),
-                    SlowTestsResultHandler(5)]
+                    TimingResultHandler(5)]
         expected = handlers[::-1]
 
         # When
@@ -290,7 +290,7 @@ class TestSortResultHandlers(unittest.TestCase):
 
         # Given
         handlers = [QuietTestResultHandler(5), VerboseTestResultHandler(5),
-                    SlowTestsResultHandler(5)]
+                    TimingResultHandler(5)]
         expected = [handlers[2], handlers[0], handlers[1]]
 
         # When

--- a/haas/plugins/tests/test_result_handlers.py
+++ b/haas/plugins/tests/test_result_handlers.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+import statistics
 
 from mock import patch
 from six.moves import StringIO
@@ -12,6 +13,7 @@ from ..result_handler import (
     TimingResultHandler,
     VerboseTestResultHandler,
     sort_result_handlers,
+    _format_stat_table,
 )
 
 
@@ -261,6 +263,87 @@ class TestTimingResultHandler(ExcInfoFixture, unittest.TestCase):
         self.assertTrue(output.startswith(output_start))
         self.assertRegexpMatches(
             output.replace('\n', ''), r'--+.*?1:01:14\.567 test_method \(')
+
+    def _calculate_statistics(self, test_durations):
+        durations_secs = [
+            i['seconds'] + (0.001 * i['milliseconds'])
+            for i in test_durations
+        ]
+        durations_secs = sorted(durations_secs, reverse=True)
+        tests_count = len(durations_secs)
+
+        mean = TestDuration(statistics.mean(durations_secs))
+        median = TestDuration(statistics.median(durations_secs))
+        stdev = TestDuration(statistics.stdev(durations_secs))
+
+        percentile_99_index = int(tests_count * 0.01)
+        percentile_95_index = int(tests_count * 0.05)
+        percentile_90_index = int(tests_count * 0.10)
+        percentile_80_index = int(tests_count * 0.20)
+
+        pairs = [
+            ['Mean', str(mean).strip()],
+            ['Std Dev', str(stdev).strip()],
+            ['Median', str(median).strip()],
+            ['80%', str(TestDuration(
+                durations_secs[percentile_99_index])).strip()],
+            ['90%', str(TestDuration(
+                durations_secs[percentile_95_index])).strip()],
+            ['95%', str(TestDuration(
+                durations_secs[percentile_90_index])).strip()],
+            ['99%', str(TestDuration(
+                durations_secs[percentile_80_index])).strip()],
+        ]
+
+        return _format_stat_table(pairs)
+
+    @patch('sys.stderr', new_callable=StringIO)
+    def test_output_multiple_tests(self, stderr):
+        # Given
+        tests_start_time = datetime(2015, 12, 23, 8, 14, 12)
+        test_durations = [
+            dict(seconds=9, milliseconds=123),
+            dict(seconds=2, milliseconds=50),
+            dict(seconds=1, milliseconds=100),
+            dict(seconds=6, milliseconds=0),
+            dict(seconds=3, milliseconds=542),
+        ]
+
+        expected_stats = self._calculate_statistics(test_durations)
+
+        test_start_time = None
+        expected_durations = []
+        for kwargs in test_durations:
+            duration = timedelta(**kwargs)
+            if test_start_time is None:
+                test_start_time = tests_start_time
+            end_time = test_start_time + duration
+            expected_durations.append(TestDuration(test_start_time, end_time))
+            test_start_time = end_time
+
+        handler = TimingResultHandler(number_to_summarize=5)
+        handler.start_test_run()
+
+        def make_case():
+            class Case(_test_cases.TestCase):
+                pass
+            return Case('test_method')
+
+        for duration in expected_durations:
+            result = TestResult.from_test_case(
+                make_case(), TestCompletionStatus.success, duration)
+            handler(result)
+
+        # When
+        handler.stop_test_run()
+
+        # Then
+        output = stderr.getvalue()
+        output_start = '\n\nTest timing report\n' + handler.separator2
+        self.assertTrue(output.startswith(output_start))
+        self.assertRegexpMatches(
+            output.replace('\n', ''), r'--+.*?0:00:09\.123 test_method \(')
+        self.assertIn(expected_stats, output)
 
 
 class TestSortResultHandlers(unittest.TestCase):

--- a/haas/plugins/tests/test_result_handlers.py
+++ b/haas/plugins/tests/test_result_handlers.py
@@ -54,7 +54,7 @@ class TestTimingResultHandler(ExcInfoFixture, unittest.TestCase):
         output_start = '\n\nTest timing report\n' + handler.separator2
         self.assertTrue(output.startswith(output_start))
         self.assertRegexpMatches(
-            output.replace('\n', ''), r'--+.*?0:00:10\.123 test_method \(')
+            output.replace('\n', ''), r'--+.*?00:10\.123 test_method \(')
 
     @patch('time.ctime')
     @patch('sys.stderr', new_callable=StringIO)
@@ -342,7 +342,7 @@ class TestTimingResultHandler(ExcInfoFixture, unittest.TestCase):
         output_start = '\n\nTest timing report\n' + handler.separator2
         self.assertTrue(output.startswith(output_start))
         self.assertRegexpMatches(
-            output.replace('\n', ''), r'--+.*?0:00:09\.123 test_method \(')
+            output.replace('\n', ''), r'--+.*?00:09\.123 test_method \(')
         self.assertIn(expected_stats, output)
 
 

--- a/haas/result.py
+++ b/haas/result.py
@@ -6,7 +6,7 @@
 # of the 3-clause BSD license.  See the LICENSE.txt file for details.
 from __future__ import absolute_import, unicode_literals
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from enum import Enum
 from functools import wraps
 import locale
@@ -106,10 +106,20 @@ class TestDuration(object):
 
     """
 
-    def __init__(self, start_time, stop_time):
-        self._start_time = start_time
-        self._stop_time = stop_time
-        self._duration = stop_time - start_time
+    def __init__(self, start_time, stop_time=None):
+        if stop_time is not None:
+            self._start_time = start_time
+            self._stop_time = stop_time
+            self._duration = stop_time - start_time
+        else:
+            # Once calculations are done, start & stop are meaningless
+            self._start_time = None
+            self._stop_time = None
+            duration = start_time
+            if not isinstance(duration, timedelta):
+                duration = timedelta(seconds=float(start_time))
+            self._duration = duration
+        self._total_seconds = None
 
     @property
     def start_time(self):
@@ -123,27 +133,40 @@ class TestDuration(object):
     def duration(self):
         return self._duration
 
+    @property
+    def total_seconds(self):
+        if self._total_seconds is None:
+            if sys.version_info < (2, 7):
+                delta = self._duration
+                total_seconds = delta.microseconds / 1000000.0 + delta.seconds
+                total_seconds += delta.days * 24 * 60 * 60
+            else:
+                total_seconds = self._duration.total_seconds()
+            self._total_seconds = total_seconds
+        return self._total_seconds
+
     def __repr__(self):
         return '<TestDuration {0}>'.format(str(self))
 
-    if sys.version_info < (2, 7):
-        def _total_seconds(self, delta):
-            seconds = delta.microseconds / 1000000.0 + delta.seconds
-            seconds += delta.days * 24 * 60 * 60
-            return seconds
-    else:
-        def _total_seconds(self, delta):
-            return delta.total_seconds()
-
     def __str__(self):
         template = '{hours: >3.0f}:{minutes:0>2.0f}:{seconds:0>2.3f}'
-        minutes, seconds = divmod(self._total_seconds(self.duration), 60)
+        minutes, seconds = divmod(self.total_seconds, 60)
         hours, minutes = divmod(minutes, 60)
         return template.format(
             hours=hours,
             minutes=minutes,
             seconds=seconds,
         )
+
+    def __add__(self, other):
+        if not isinstance(other, TestDuration):
+            return NotImplemented
+        return TestDuration(self.duration + other.duration)
+
+    def __truediv__(self, divisor):
+        if not isinstance(self, TestDuration) and isinstance(divisor, int):
+            return NotImplemented
+        return TestDuration(self.duration / divisor)
 
     def __eq__(self, other):
         if not hasattr(other, 'duration'):

--- a/haas/result.py
+++ b/haas/result.py
@@ -189,6 +189,16 @@ class TestDuration(object):
     def as_integer_ratio(self):
         return self.total_seconds.as_integer_ratio()
 
+    def __add__(self, other):
+        if not isinstance(other, TestDuration):
+            return NotImplemented
+        return TestDuration(self.duration + other.duration)
+
+    def __truediv__(self, divisor):
+        if not isinstance(self, TestDuration) and isinstance(divisor, int):
+            return NotImplemented
+        return TestDuration(self.duration / divisor)
+
 
 class TestResult(object):
     """Container object for all information related to the run of a single

--- a/haas/result.py
+++ b/haas/result.py
@@ -158,16 +158,6 @@ class TestDuration(object):
             seconds=seconds,
         )
 
-    def __add__(self, other):
-        if not isinstance(other, TestDuration):
-            return NotImplemented
-        return TestDuration(self.duration + other.duration)
-
-    def __truediv__(self, divisor):
-        if not isinstance(self, TestDuration) and isinstance(divisor, int):
-            return NotImplemented
-        return TestDuration(self.duration / divisor)
-
     def __eq__(self, other):
         if not hasattr(other, 'duration'):
             return NotImplemented
@@ -194,6 +184,10 @@ class TestDuration(object):
 
     def __hash__(self):
         return hash((self._start_time, self._stop_time))
+
+    # To support statistics.mean() on TestDuration objects
+    def as_integer_ratio(self):
+        return self.total_seconds.as_integer_ratio()
 
 
 class TestResult(object):

--- a/haas/result.py
+++ b/haas/result.py
@@ -149,7 +149,7 @@ class TestDuration(object):
         return '<TestDuration {0}>'.format(str(self))
 
     def __str__(self):
-        template = '{hours: >3.0f}:{minutes:0>2.0f}:{seconds:0>2.3f}'
+        template = '{hours: >3.0f}:{minutes:0>2.0f}:{seconds:0>6.3f}'
         minutes, seconds = divmod(self.total_seconds, 60)
         hours, minutes = divmod(minutes, 60)
         return template.format(

--- a/haas/result.py
+++ b/haas/result.py
@@ -149,11 +149,16 @@ class TestDuration(object):
         return '<TestDuration {0}>'.format(str(self))
 
     def __str__(self):
-        template = '{hours: >3.0f}:{minutes:0>2.0f}:{seconds:0>6.3f}'
+        hours_template = '{hours: >3.0f}:'
+        template = '{hours_fmt}{minutes:0>2.0f}:{seconds:0>6.3f}'
         minutes, seconds = divmod(self.total_seconds, 60)
         hours, minutes = divmod(minutes, 60)
+        if hours > 0:
+            hours_fmt = hours_template.format(hours=hours)
+        else:
+            hours_fmt = ''
         return template.format(
-            hours=hours,
+            hours_fmt=hours_fmt,
             minutes=minutes,
             seconds=seconds,
         )

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,7 @@ if not is_released:
 
 if __name__ == "__main__":
     install_requires = ['six']
-    common_requires = ['enum34']
+    common_requires = ['enum34', 'statistics']
     py26_requires = [
         'stevedore >= 1.0.0, < 1.10.0',
         'unittest2',

--- a/setup.py
+++ b/setup.py
@@ -169,7 +169,7 @@ if __name__ == "__main__":
                 'default = haas.plugins.result_handler:StandardTestResultHandler',  # noqa
                 'quiet = haas.plugins.result_handler:QuietTestResultHandler',
                 'verbose = haas.plugins.result_handler:VerboseTestResultHandler',  # noqa
-                'slow = haas.plugins.result_handler:SlowTestsResultHandler',
+                'timing = haas.plugins.result_handler:TimingResultHandler',
             ]
         },
         extras_require={


### PR DESCRIPTION
@itziakos Update to the test time summary.

```
$ haas --summarize-test-time
........................................................................................................................................................................................................................

Test timing report
----------------------------------------------------------------------
  00:00.020 test_with_coverage_plugin (haas.tests.test_haas_application.TestHaasApplication)
  00:00.006 test_with_logging (haas.tests.test_haas_application.TestHaasApplication)
  00:00.005 test_multiple_start_directories (haas.tests.test_haas_application.TestHaasApplication)
  00:00.005 test_main_quiet (haas.tests.test_haas_application.TestHaasApplication)
  00:00.005 test_main_buffer (haas.tests.test_haas_application.TestHaasApplication)
  00:00.005 test_buffering_stderr (haas.tests.test_result.TestBuffering)
  00:00.004 test_main_default_arguments (haas.tests.test_haas_application.TestHaasApplication)
  00:00.004 test_main_failfast (haas.tests.test_haas_application.TestHaasApplication)
  00:00.004 test_discover_package_no_top_level (haas.plugins.tests.test_discoverer.TestDiscoveryByModule)
  00:00.004 test_main_quiet_and_verbose_not_allowed (haas.tests.test_haas_application.TestHaasApplication)

 Mean      | Std Dev   | Median    | 80%       | 90%       | 95%       | 99%      
-----------+-----------+-----------+-----------+-----------+-----------+-----------
 00:00.001 | 00:00.002 | 00:00.000 | 00:00.005 | 00:00.004 | 00:00.002 | 00:00.001


----------------------------------------------------------------------
Ran 216 tests in 0.198s

OK
```