### PR TITLE
Use absolute import for main entry point.

### DIFF
--- a/haas/__main__.py
+++ b/haas/__main__.py
@@ -6,7 +6,7 @@
 # of the 3-clause BSD license.  See the LICENSE.txt file for details.
 import sys  # pragma: no cover
 
-from .main import main  # pragma: no cover
+from haas.main import main  # pragma: no cover
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This works arounds an issue that I had under Windows when running haas under `coverage`. I don't have a test to go with this, but below is a minimal working example that exhibits the issue.

I'm running Python 3.5.2 on Windows 10. Relevant package versions: haas 0.7.0, coverage 4.2.

To reproduce, run `coverage -m haas -v mwe`, where the file `mwe.py` has the following content:
```python
import unittest
from concurrent.futures import ProcessPoolExecutor

class TestSomething(unittest.TestCase):
    def test_something(self):
        with ProcessPoolExecutor(max_workers=1) as executor:
            future = executor.submit(do_nothing)
            future.result()

def do_nothing():
    pass
```

Output:
```
(.env) PS C:\Users\joris\Desktop> coverage run -m haas -v mwe
[Thu Dec 15 06:32:18 2016] (1/1) test_something (mwe.TestSomething) ... Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "C:\Users\joris\Appdata\Local\Programs\Python\Python35\lib\multiprocessing\spawn.py", line 106, in spawn_main
    exitcode = _main(fd)
  File "C:\Users\joris\Appdata\Local\Programs\Python\Python35\lib\multiprocessing\spawn.py", line 115, in _main
    prepare(preparation_data)
  File "C:\Users\joris\Appdata\Local\Programs\Python\Python35\lib\multiprocessing\spawn.py", line 226, in prepare
    _fixup_main_from_path(data['init_main_from_path'])
  File "C:\Users\joris\Appdata\Local\Programs\Python\Python35\lib\multiprocessing\spawn.py", line 278, in _fixup_main_from_path
    run_name="__mp_main__")
  File "C:\Users\joris\Appdata\Local\Programs\Python\Python35\lib\runpy.py", line 254, in run_path
    pkg_name=pkg_name, script_name=fname)
  File "C:\Users\joris\Appdata\Local\Programs\Python\Python35\lib\runpy.py", line 96, in _run_module_code
    mod_name, mod_spec, pkg_name, script_name)
  File "C:\Users\joris\Appdata\Local\Programs\Python\Python35\lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "c:\users\joris\desktop\edm\.env\lib\site-packages\haas\__main__.py", line 9, in <module>
    from .main import main  # pragma: no cover
SystemError: Parent module '' not loaded, cannot perform relative import
ERROR
```